### PR TITLE
Fixed nginx URL will cause start with "mars" file name cannot fetch.

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -89,7 +89,7 @@ http {
             index index.html;
         }
 
-        location /mars {
+        location /mars/ {
             proxy_pass https://127.0.0.1;
             proxy_redirect https://127.0.0.1/ /;
 


### PR DESCRIPTION
Fixed nginx URL will cause start with "mars" file name cannot fetch.