### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
         - ./conf/tftpserver:/etc/xinetd.d
         - ./swi:/opt/
         - ./download:/opt/download
-        - ./public:/opt/public
+        #- ./public:/opt/public
     #depends_on:
     #  - mars
     network_mode: host


### PR DESCRIPTION
For K8s already build in the public folder, here we can skip it. For testing, we can unmark it